### PR TITLE
メール送信用の設定ができるスクリプトを追加 (#53)(#58)

### DIFF
--- a/inst-script/config-email.sh
+++ b/inst-script/config-email.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+if [ "$SMTPSET" == "" ]
+then
+echo "*******************************************************"
+echo "  メール設定"
+echo "*******************************************************"
+echo "Redmineのシステムメールを送信するための設定を行います。"
+echo ""
+echo "＜利用する上での注意＞"
+echo "・利用したいメールシステムと通信可能なことをご確認ください。ファイアーウォールなどで遮断されている場合は管理者にお問い合わせください。"
+echo "・Sendmailコマンドを利用する場合、別途Sendmailの設定を行う必要があります。"
+echo "・G-Mail/Hotmailを利用する場合、ユーザー名とパスワードがあれば利用可能です。"
+echo ""
+echo "次の中から、使いたいメールシステムを選択してください。"
+echo "ここでメール設定を行わない場合は「N」を選択してください。"
+echo ""
+echo "0. 独自のメールサーバーを設定する"
+echo "1. Linux内のSendmailコマンドを使用する"
+echo "2. G-Mail/Google Apps"
+echo "3. Windows Live Hotmail"
+echo ""
+echo "N. メール設定をしない"
+echo ""
+echo -n "番号選択: "
+read SMTPSET
+echo ""
+echo ""
+fi
+
+case "$SMTPSET" in
+	"0" ) 
+	echo "*******************************************************"
+	echo "  メールサーバー設定"
+	echo "*******************************************************"
+
+	if [ "$SMTPSERVER" == "" ]
+	then
+		echo "SMTPサーバー名を入力してください"
+		echo ""
+		echo -n "SMTPサーバー: "
+		read SMTPSERVER
+		echo ""
+		echo ""
+	fi
+
+	if [ "$SMTPTLS" == "" ]
+	then
+		echo ""
+		echo "暗号化が必要なメールサーバーですか？"
+		echo "SSL/TLS暗号化が必要な場合は「Y」、不要な場合は「n」を入力してください。"
+		echo ""
+		echo -n "暗号化が必要ですか？[Y/n]: "
+		read SMTPTLS
+		echo ""
+		echo ""
+	fi
+	
+	if [ "$SMTPPORT" == "" ]
+	then
+		echo ""
+		echo "メール送信に使用するポート番号を入力してください。"
+		echo "・通常は「25」で設定します。"
+		echo "・暗号化を行なっているサーバーや、迷惑メール対策(Port25 Blocking)のサブミッションポートを使う場合などは違うポートになります。"
+		echo ""
+		echo -n "ポート番号: "
+		read SMTPPORT
+		echo ""
+		echo ""
+	fi	
+	
+	if [ "$SMTPLOGIN" == "" ]
+	then
+		echo ""
+		echo "メール送信時、サーバーで認証(ログイン)する必要はありますか？"
+		echo "認証が必要な場合は「Y」、不要な場合は「n」を入力してください。"
+		echo ""
+		echo -n "ログインが必要ですか？[Y/n]: "
+		read SMTPLOGIN
+		echo ""
+		echo ""
+	fi	
+
+	if [ "$SMTPLOGIN" == "Y" ]
+	then	
+
+		if [ "$SMTPUser" == "" ]
+		then
+			echo ""
+			echo "SMTPユーザー名を入力してください。"
+			echo ""
+			echo -n "ユーザー名: "
+			read SMTPUser
+			echo ""
+			echo ""
+		fi
+
+		if [ "$SMTPPass" == "" ]
+		then
+			echo ""
+			echo "SMTPパスワードを入力してください。"
+			echo ""
+			echo -n "パスワード: "
+			read SMTPPass
+			echo ""
+			echo ""
+		fi		
+	fi	
+	;;
+
+	"1" ) echo "「Linux内のSendmailコマンドを使用する」を選択しました。"
+	;;
+
+	"2" )
+	echo "*******************************************************"
+	echo "  G-Mail/Google Apps設定"
+	echo "*******************************************************"
+	
+	if [ "$SMTPUser" == "" ]
+	then
+		echo "G-Mailのユーザー名を入力してください。"
+		echo ""
+		echo -n "ユーザー名: "
+		read SMTPUser
+		echo ""
+		echo ""
+	fi
+	
+	if [ "$SMTPPass" == "" ]
+	then
+		echo ""
+		echo "G-Mailのパスワードを入力してください。"
+		echo ""
+		echo -n "パスワード: "
+		read SMTPPass
+		echo ""
+		echo ""
+	fi
+
+	SMTPSERVER=smtp.gmail.com
+	SMTPTLS=Y
+	SMTPPORT=465
+	SMTPLOGIN=Y
+	;;
+	
+	"3" )
+	echo "*******************************************************"
+	echo "  Windows Live Hotmail設定"
+	echo "*******************************************************"
+	
+	if [ "$SMTPUser" == "" ]
+	then
+		echo "HotmailのMicrosoftアカウントを入力してください。"
+		echo ""
+		echo -n "Microsoftアカウント: "
+		read SMTPUser
+		echo ""
+		echo ""
+	fi
+	
+	if [ "$SMTPPass" == "" ]
+	then
+		echo ""
+		echo "Hotmailのパスワードを入力してください。"
+		echo ""
+		echo -n "パスワード: "
+		read SMTPPass
+		echo ""
+		echo ""
+	fi
+
+	SMTPSERVER=smtp.live.com
+	SMTPTLS=n
+	SMTPPORT=587
+	SMTPLOGIN=Y
+	;;
+	
+	* ) echo "メール設定を行いません。" ;;
+esac

--- a/inst-script/gen-email-config.sh
+++ b/inst-script/gen-email-config.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+case "$SMTPSET" in
+	"1" )
+	echo "default:
+ email_delivery:
+    delivery_method: :sendmail" > $INSTALL_DIR/config/configuration.yml
+	;;
+	
+	"0" | "2" | "3" )
+	echo "default:
+ email_delivery:
+    delivery_method: :smtp
+    smtp_settings:
+      address: $SMTPSERVER
+      port: $SMTPPORT
+      domain: $HOSTNAME" > $INSTALL_DIR/config/configuration.yml
+
+	if [ "$SMTPTLS" == "Y" ]
+	then
+	echo "      tls: true" >> $INSTALL_DIR/config/configuration.yml
+	fi
+
+	if [ "$SMTPLOGIN" == "Y" ]
+	then
+	echo "      authentication: :login
+      user_name: $SMTPUser
+      password: $SMTPPass" >> $INSTALL_DIR/config/configuration.yml
+	fi
+	;;
+	
+	* ) ;;
+esac
+

--- a/smelt
+++ b/smelt
@@ -125,12 +125,12 @@ echo ""
 echo "などのコマンドで、SSLの証明書を無効にする必要があります。"
 echo ""
 echo -n "SSL(https)サポートを有効にしますか?(y/N) "
-
 read SSL
 echo ""
 echo ""
 fi
 
+source inst-script/config-email.sh
 
 #if [ $TYPE = "" ]
 #then
@@ -269,6 +269,8 @@ $CPCMD hooks $INSTALL_DIR/
 #chown $APACHE_USER.$APACHE_USER -R /var/opt/alminium
 chown -R $APACHE_USER:$APACHE_USER $INSTALL_DIR
 chown -R $APACHE_USER:$APACHE_USER /var/opt/alminium
+
+source inst-script/gen-email-config.sh
 
 source inst-script/$OS/post-install
 


### PR DESCRIPTION
メール設定スクリプトをファイルにして、メインスクリプトから呼び出すようにした。
全OS共通で使えるように設定。
メールパラメーター収集時の説明文を詳しくした。
#58 で指摘された問題を改善しました。

Windows AzureのUbuntu12.04とAmazon Linuxで動いたところまでは確認しています。
