### PR TITLE
プロキシ必須環境下での jenkins インストールが終了しない

### DIFF
--- a/inst-script/rhel6/jenkins-install
+++ b/inst-script/rhel6/jenkins-install
@@ -42,7 +42,7 @@ RET=-1
 until  [ "$RET" -eq "0" ]
 do
   sleep 3
-  wget  -O $INSTALL_DIR/bin/jenkins-cli.jar http://localhost:8080/jenkins/jnlpJars/jenkins-cli.jar
+  wget --no-proxy -O $INSTALL_DIR/bin/jenkins-cli.jar http://localhost:8080/jenkins/jnlpJars/jenkins-cli.jar
   RET=$?
 done
 
@@ -52,7 +52,24 @@ wget -O /tmp/default.js http://updates.jenkins-ci.org/update-center.json
 sed '1d;$d' /tmp/default.js > /tmp/default.json
   
 # Now push it to the update URL
-curl -X POST -H "Accept: application/json" -d @/tmp/default.json http://localhost:8080/jenkins/updateCenter/byId/default/postBack --verbose
+curl --noproxy localhost -X POST -H "Accept: application/json" -d @/tmp/default.json http://localhost:8080/jenkins/updateCenter/byId/default/postBack --verbose
+
+if [ x"$http_proxy" != x"" ]
+then
+  # set proxy. sorry IPv4 only and user:pass not supported...
+  proxyserver=`echo $http_proxy | cut -d':' -f2 | sed 's/\/\///g'`
+  proxyport=`echo $http_proxy | cut -d':' -f3 | sed 's/\///g'`
+  #echo $proxyserver
+  #echo $proxyport
+  curl --noproxy localhost -X POST --data "json={\"name\": \"$proxyserver\", \"port\": \"$proxyport\", \"userName\": \"$proxyuser\", \"password\": \"$proxypass\", \"noProxyHost\": \"\"}" http://localhost:8080/jenkins/pluginManager/proxyConfigure --verbose
+  RET=$?
+  if [ "$RET" -ne "0" ]
+  then
+    echo "proxy setting for jenkins fail"
+    exit 1
+  fi
+  #service jenkins restart
+fi
 
 RET=-1
 until  [ "$RET" -eq "0" ]


### PR DESCRIPTION
ファイヤーウォールの内側のマシンで jenkins をインストールしようとすると
無限リトライしたので修正してみました。

DNS, HTTP, HTTPS が行えるのはプロキシからのみの環境をエミュレートして作成してます。
