### PR TITLE
Mac OS X 10.6.8(Snow Leopard) の cp コマンドで無効な引数に対応

### DIFF
--- a/inst-script/redmine-plugins
+++ b/inst-script/redmine-plugins
@@ -46,7 +46,7 @@ do
           git checkout ${DIR_NAME[$i]}
           cd ../..
           $RMCMD $INSTALL_DIR/plugins/${DEST_NAME[$i]}
-          cp -ar cache/${DEST_NAME[$i]} $INSTALL_DIR/plugins/
+          ${CPCMD}a cache/${DEST_NAME[$i]} $INSTALL_DIR/plugins/
         fi
         ;;
     *)
@@ -69,7 +69,7 @@ do
           fi
         fi
         $RMCMD $INSTALL_DIR/plugins/${DEST_NAME[$i]}
-        cp -ar cache/${DEST_NAME[$i]} $INSTALL_DIR/plugins/${DEST_NAME[$i]}
+        ${CPCMD}a cache/${DEST_NAME[$i]} $INSTALL_DIR/plugins/${DEST_NAME[$i]}
         ;;
     esac
 done


### PR DESCRIPTION
git の plugin がインストールされなかったので調査したところ cp コマンドの -r が
`cp: the -R and -r options may not be specified together.`
というエラーになってたので。

直前の $RMCMD で $INSTALL_DIR のプラグインを消しているので、セットされている $CPCMD(cp -fr系) でも問題ないかと思い修正。
