### PR TITLE
configration.ymlのメール設定をRedmine2.xに対応させた

### DIFF
--- a/inst-script/gen-email-config.sh
+++ b/inst-script/gen-email-config.sh
@@ -18,7 +18,7 @@ case "$SMTPSET" in
 
 	if [ "$SMTPTLS" == "Y" ]
 	then
-	echo "      tls: true" >> $INSTALL_DIR/config/configuration.yml
+	echo "      enable_starttls_auto: true" >> $INSTALL_DIR/config/configuration.yml
 	fi
 
 	if [ "$SMTPLOGIN" == "Y" ]


### PR DESCRIPTION
[issue #75](https://github.com/alminium/alminium/issues/75)と同様の理由(rubyのメール送信機能の影響)により、
Redmine2.xにおけるconfiguration.ymlのメール設定方法が変更されていたようです。
これにより、gmailでのメール通知が出来なくなっていたため、修正しました。

Amazon AMI Linux 2011.09に修正したものをインストールし、
gmailおよびwindows live mailによるメール通知が正しく動作することを確認しました。

参考：
configuration.ymlの設定項目 | Redmine.JP
http://redmine.jp/config/configuration_yml/

Error while sending email through Gmail. - Redmine 
http://www.redmine.org/boards/2/topics/30670
