### PR TITLE
fixed debian install

### DIFF
--- a/inst-script/debian/httpd-redmine.conf
+++ b/inst-script/debian/httpd-redmine.conf
@@ -1,5 +1,5 @@
-LoadModule passenger_module /var/lib/gems/1.9.1/gems/passenger-%PASSENGER_VERSION%/buildout/apache2/mod_passenger.so 
-PassengerRoot /var/lib/gems/1.9.1/gems/passenger-%PASSENGER_VERSION%
+LoadModule passenger_module /usr/lib/ruby/gems/1.9.1/gems/passenger-%PASSENGER_VERSION%/buildout/apache2/mod_passenger.so 
+PassengerRoot /usr/lib/ruby/gems/1.9.1/gems/passenger-%PASSENGER_VERSION%
 PassengerRuby /usr/bin/ruby1.9.3
 
 <VirtualHost *:80>

--- a/inst-script/debian/pre-install
+++ b/inst-script/debian/pre-install
@@ -1,6 +1,7 @@
 #!/bin/bash
 apt-get update
 apt-get -y -qq install `grep -v "^#" inst-script/debian/packages.lst`
+REALLY_GEM_UPDATE_SYSTEM=1 gem update --system
 
 if [ "$SSL" = "y" ]
 then


### PR DESCRIPTION
Issue #104 の問題に対応するための修正です。

Ubuntu 12.04 でインストールされるruby1.9.3ではgemのバージョンが低かったため強制的にアップデートさせるようにしました。
また、そうするとpassengerのパスが変わってしまうのでそちらの修正もいれました。

動作は http://www.vagrantbox.es/ の `Official Ubuntu 12.04 daily Cloud Image amd64 (VirtualBox 4.1.12)`を使用して確認しました。
なお、このvagrant boxではデフォルトでruby1.8がインストールされていたので以下のようにprovisioningであらかじめアンインストールしています。

```
  config.vm.provision :shell do |shell|
    shell.inline = <<DOC
cd /tmp
apt-get update
apt-get -y remove ruby ruby1.8 ruby1.8-dev rubygems puppet
apt-get -y autoremove
apt-get -y install git
git clone https://github.com/taksatou/alminium.git
# cd alminium
# bash ./smelt
DOC
```
