### PR TITLE
redmine_git_branch_hookのredmine/scm/adapters (LoadError)

### DIFF
--- a/config/redmine-plugins.lst
+++ b/config/redmine-plugins.lst
@@ -29,6 +29,6 @@ redmine_banner,master,https://github.com/akiko-pusu/redmine_banner.git
 open_flash_chart,master,https://github.com/pullmonkey/open_flash_chart.git
 redmine_charts,develop,https://github.com/drakontia/redmine_charts.git
 redmine_local_avatars,master,https://github.com/luckval/redmine_local_avatars.git
-redmine_git_branch_hook,master,https://github.com/mikoto20000/redmine_git_branch_hook.git
+redmine_git_branch_hook,config-merge-branch,https://github.com/mikoto20000/redmine_git_branch_hook.git
 # advanced_roadmapはbacklogsと競合するためどちらかを選択
 #advanced_roadmap,advanced_roadmap,https://ociotec.com/redmine/attachments/download/155/advanced_roadmap.0.5.1.tar.gz


### PR DESCRIPTION
CentOS 6.4 64bit 環境でalminiumをインストールしましたがsmeltの最後のあたりでrake aborted!となり,alminiumのURLにアクセスすると以下が表示されました。

```
Web application could not be started

cannot load such file -- redmine/scm/adapters (LoadError)
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `require'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `block in require'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:236:in `load_dependency'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `require'
  /opt/alminium/plugins/redmine_git_branch_hook/lib/git_adapter_patch.rb:1:in `<top (required)>'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `require'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `block in require'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:236:in `load_dependency'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `require'
  /opt/alminium/plugins/redmine_git_branch_hook/init.rb:2:in `<top (required)>'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `require'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `block in require'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:236:in `load_dependency'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:251:in `require'
  /opt/alminium/lib/redmine/plugin.rb:130:in `block in load'
  /opt/alminium/lib/redmine/plugin.rb:121:in `each'
  /opt/alminium/lib/redmine/plugin.rb:121:in `load'
  /opt/alminium/config/initializers/30-redmine.rb:12:in `<top (required)>'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `block in load'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:236:in `load_dependency'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:245:in `load'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/engine.rb:588:in `block (2 levels) in <class:Engine>'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/engine.rb:587:in `each'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/engine.rb:587:in `block in <class:Engine>'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:30:in `instance_exec'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:30:in `run'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:55:in `block in run_initializers'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:54:in `each'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/initializable.rb:54:in `run_initializers'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/application.rb:136:in `initialize!'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/railties-3.2.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
  /opt/alminium/config/environment.rb:14:in `<top (required)>'
  config.ru:3:in `require'
  config.ru:3:in `block in <main>'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/rack-1.4.5/lib/rack/builder.rb:51:in `instance_eval'
  /opt/alminium/vendor/bundler/ruby/2.0.0/gems/rack-1.4.5/lib/rack/builder.rb:51:in `initialize'
  config.ru:1:in `new'
  config.ru:1:in `<main>'
  /usr/lib64/ruby/gems/2.0.0/gems/passenger-4.0.33/helper-scripts/rack-preloader.rb:107:in `eval'
  /usr/lib64/ruby/gems/2.0.0/gems/passenger-4.0.33/helper-scripts/rack-preloader.rb:107:in `preload_app'
  /usr/lib64/ruby/gems/2.0.0/gems/passenger-4.0.33/helper-scripts/rack-preloader.rb:152:in `<module:App>'
  /usr/lib64/ruby/gems/2.0.0/gems/passenger-4.0.33/helper-scripts/rack-preloader.rb:29:in `<module:PhusionPassenger>'
  /usr/lib64/ruby/gems/2.0.0/gems/passenger-4.0.33/helper-scripts/rack-preloader.rb:28:in `<main>'
```

<code>/opt/alminium/plugins/redmine_git_branch_hook/lib/git_adapter_patch.rb</code>を直接編集しredmine_git_branch_hookの [Support Redmine 2.4.x. · d092494 · mikoto20000/redmine_git_branch_hook](https://github.com/mikoto20000/redmine_git_branch_hook/commit/d0924945e8cd017049f43fc815b9719343fbbcf2) の修正を外したらalminumのトップ画面が表示されました。
