### PR TITLE
rpmファイルのパスをRuby2.1.2に対応するように修正

### DIFF
--- a/inst-script/rhel6/pre-install
+++ b/inst-script/rhel6/pre-install
@@ -42,7 +42,7 @@ chkconfig --add mysqld
 chkconfig mysqld on
 service mysqld start
 
-if [[ `which ruby` == "" || ! `ruby --version` =~ 2.1.0 ]]
+if [[ `which ruby` == "" || ! `ruby --version` =~ 2.1. ]]
 then
     bash inst-script/rhel6/ruby2.1-install
 fi

--- a/inst-script/rhel6/ruby2.1-install
+++ b/inst-script/rhel6/ruby2.1-install
@@ -28,7 +28,7 @@ then
   cd ~/rpmbuild/SPECS
   rpmbuild -bb ruby21x.spec
   ARCH=`uname -m`
-  rpm -Uvh ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.0*.rpm
+  rpm -Uvh ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.*.rpm
 
   popd
 fi


### PR DESCRIPTION
ruby21x.specのRubyバージョンが2.1.2に上がったことによって、Rubyのインストールが失敗するようになっていました。

rpmファイルのパスを修正し、Ruby2.1.2がインストールできることを確認しました。
