### PR TITLE
認証プロキシをjenkinsに正しく設定するようにした。

### DIFF
--- a/inst-script/rhel6/jenkins-install
+++ b/inst-script/rhel6/jenkins-install
@@ -53,6 +53,16 @@ curl --noproxy localhost -X POST -H "Accept: application/json" -d @/tmp/default.
 if [ x"$http_proxy" != x"" ]
 then
   # set proxy. sorry IPv4 only and user:pass not supported...
+  proxyuser=`echo $http_proxy | sed 's/.*:\/\/\([a-zA-Z0-9]*\):.*/\1/'`
+  proxypass=`echo $http_proxy | sed 's/.*:\/\/[a-zA-Z0-9]*:\([a-zA-Z0-9:]*\)\@.*/\1/'`
+  #echo proxyuser=$proxyuser
+  #echo proxypass=$proxypass
+
+  if [ x"$proxyuser" != x"" ]
+  then
+    http_proxy=`echo $http_proxy | sed "s/$proxyuser:$proxypass\@//"`
+  fi
+
   proxyserver=`echo $http_proxy | cut -d':' -f2 | sed 's/\/\///g'`
   proxyport=`echo $http_proxy | cut -d':' -f3 | sed 's/\///g'`
   #echo $proxyserver


### PR DESCRIPTION
認証プロキシの場合(例: http_proxy=http://okamototk:password@proxyhost.com:8080/)の場合、proxyuser/proxypassをJenkinsに設定するが、その変数をパースするコードが存在しなかったので追加した。
