### PR TITLE
インストール後の確認をserverspecで行う

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.bundle/
+Gemfile.lock
+cache/
+gems.installed
+packages.installed
+vendor/bundler/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'serverspec'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = 'spec/*/*_spec.rb'
+end
+
+task :default => :spec

--- a/spec/localhost/httpd_spec.rb
+++ b/spec/localhost/httpd_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+if os[:family] == 'RedHat'
+  describe package('httpd') do
+    it { should be_installed }
+  end
+
+  describe service('httpd') do
+    it { should be_enabled   }
+    it { should be_running   }
+  end
+
+  describe port(80) do
+    it { should be_listening }
+  end
+
+  describe file('/etc/httpd/conf.d/maven.conf') do
+    it { should be_file }
+  end
+
+  describe file('/etc/httpd/conf.d/redmine.conf') do
+    it { should be_file }
+  end
+
+  describe file('/etc/httpd/conf.d/vcs.conf') do
+    it { should be_file }
+  end
+else
+  puts "*** This test is NOT supported on #{os[:family]}."
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+include SpecInfra::Helper::Exec
+include SpecInfra::Helper::DetectOS
+
+RSpec.configure do |c|
+  if ENV['ASK_SUDO_PASSWORD']
+    require 'highline/import'
+    c.sudo_password = ask("Enter sudo password: ") { |q| q.echo = false }
+  else
+    c.sudo_password = ENV['SUDO_PASSWORD']
+  end
+end


### PR DESCRIPTION
正しくインストールが完了したかどうかの確認をserverspecでやってみました。
Redmine本体やプラグインのバージョンを上げたときに、簡単に確認できるようにしていけると良いなぁと思っています。

実行例（rootユーザで実行）

``` text
# bundle install --path vendor/bundler
# bundle exec rake spec
/usr/bin/ruby -S rspec spec/localhost/httpd_spec.rb
.......

Finished in 0.08724 seconds
7 examples, 0 failures
```

ひとまずの形だけということでRedHat系のみを対象に以下の確認を行っています。
- httpdがインストールされていること
- httpdが自動起動になっていること
- httpdが起動していること
- ポート80番をListenしていること
- /etc/httpd/conf.d/maven.conf がファイルとして存在していること
- /etc/httpd/conf.d/redmine.conf がファイルとして存在していること
- /etc/httpd/conf.d/vcs.conf がファイルとして存在していること

今後、プラグイン関連のテストを追加していけると良いかなと思います。
