### PR TITLE
ubuntu13.10以降対応

### DIFF
--- a/inst-script/debian/packages.lst
+++ b/inst-script/debian/packages.lst
@@ -33,5 +33,6 @@ libapache-dbi-perl
 #gcc
 # for backlogs
 #libnokogiri-ruby
-libical0
+libical[01]
 python-docutils
+ruby-dev


### PR DESCRIPTION
- ubuntu13.10からlibical0ではなくlibical1が提供されています。
  http://packages.ubuntu.com/search?section=all&arch=any&keywords=libical&searchon=names
- ruby-devが必要でした。(Checking for Ruby development headers...でno)
- ubuntu 14.10でsmeltの動作を確認。
