### PR TITLE
サブモジュールの変更をローカルリポジトリに反映できるようにした (#144)

### DIFF
--- a/smelt
+++ b/smelt
@@ -178,6 +178,14 @@ case $TYPE in
         ;;
 esac
 
+# update submodules
+if [ $(git config -l | egrep 'submodule.+url=' | wc -l) -ne \
+     $(grep submodule .gitmodules | wc -l) ]
+then
+  git submodule init
+fi
+git submodule sync
+git submodule update
 
 ## install packages
 if [ ! -f packages.installed ]
@@ -185,12 +193,6 @@ then
   echo "*** run pre-install script ***"
   source inst-script/$OS/pre-install
   touch packages.installed
-fi
-
-if [ ! -f theme/railsgun/license.txt ]
-then
-  git submodule init
-  git submodule update
 fi
 
 if [ ! -f gems.installed ]


### PR DESCRIPTION
以下の環境でインストール確認した。
- Ubuntu 12.04.5 LTS x86_64（git version 1.7.9.5）
- CentOS 6.5 x86_64（git version 1.7.1）

**【補足】**
- Ubuntu 12.04.5で意図した通りの動作になることを確認した。
- CentOS 6.5のgitのバージョンでは `git sync` を実行してもサブモジュールのURLが
  リポジトリのローカル設定に反映されないため、この修正を適用しても動作に変化なし。
- 他の環境は未確認だが、gitのバージョンが上記より新しければ、意図した通りに動作
  するものと思われる。
