### PR TITLE
rhel6 スクリプトのapache用設定を反映

### DIFF
--- a/inst-script/debian/httpd-redmine.conf
+++ b/inst-script/debian/httpd-redmine.conf
@@ -42,3 +42,27 @@ ExpiresByType text/css A2592000
 </VirtualHost>
 
 </IfModule>
+
+Alias /plugin_assets /opt/alminium/public/plugin_assets
+<Directory /opt/alminium/public/plugin_assets>
+  Allow from all
+  PassengerEnabled off
+</Directory>
+
+Alias /stylesheets /opt/alminium/public/stylesheets
+<Directory /opt/alminium/public/stylesheets>
+  Allow from all
+  PassengerEnabled off
+</Directory>
+
+Alias /javascripts /opt/alminium/public/javascripts
+<Directory /opt/alminium/public/javascritps>
+  Allow from all
+  PassengerEnabled off
+</Directory>
+
+Alias /images /opt/alminium/public/images
+<Directory /opt/alminium/public/images>
+  Allow from all
+  PassengerEnabled off
+</Directory>


### PR DESCRIPTION
**【内容】**

`inst-script/rhel6/httpd-redmine.conf` の以下のチェンジセットの内容を `inst-script/debian/httpd-redmine.conf` に反映した。
- ecaf15b Apacheのファイルのハンドリングを改善
- 95b41a0 Redmineの静的ファイル読み込み時の高速化

**【動作確認】**
- Ubuntu 12.04.5 LTS x86_64
