### PR TITLE
パッケージインストール情報を出力するように修正

### DIFF
--- a/inst-script/debian/jenkins-install
+++ b/inst-script/debian/jenkins-install
@@ -2,8 +2,8 @@
 
 wget -q -O - http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | sudo apt-key add -
 echo "deb http://pkg.jenkins-ci.org/debian binary/" > /etc/apt/sources.list.d/jenkins.list
-apt-get update
-apt-get -y -qq install jenkins
+apt-get -q2 update
+apt-get -y install jenkins
 
 if [ ! -d /var/lib/jenkins/persona ]
 then

--- a/inst-script/debian/pre-install
+++ b/inst-script/debian/pre-install
@@ -1,6 +1,6 @@
 #!/bin/bash
-apt-get update
-apt-get -y -qq install `grep -v "^#" inst-script/debian/packages.lst`
+apt-get -q2 update
+apt-get -y install `grep -v "^#" inst-script/debian/packages.lst`
 REALLY_GEM_UPDATE_SYSTEM=1 gem update --system
 
 if [ "$SSL" = "y" ]


### PR DESCRIPTION
**【内容】**
debianのパッケージインストールの出力を以下の通り修正
- `apt-get update` コマンドの出力は邪魔になるだけなので出力しないようにした
- `apt-get install` コマンドの出力は成功／失敗／未処理の結果が分かったほうがよいので出力するようにした

**【動作確認】**
- Ubuntu 12.04.5 LTS x86_64
