### PR TITLE
アンインストール時にalminiumユーザを削除する

### DIFF
--- a/config/createdb.sql
+++ b/config/createdb.sql
@@ -1,4 +1,2 @@
-create database alminium DEFAULT CHARACTER SET utf8;
-create user 'alminium' identified by 'alminium';
-grant all privileges on alminium.* to alminium@localhost IDENTIFIED by 'alminium';
-
+CREATE DATABASE alminium DEFAULT CHARACTER SET utf8;
+GRANT ALL PRIVILEGES ON alminium.* TO alminium@localhost IDENTIFIED BY 'alminium';

--- a/uninstall
+++ b/uninstall
@@ -14,7 +14,10 @@ read YN
 
 if [ "$YN" = "y" ]
 then
-    mysql alminium -e "drop database alminium" 
+    mysql alminium -e "REVOKE ALL ON alminium.* FROM alminium@localhost"
+    mysql alminium -e "DELETE FROM mysql.user WHERE User LIKE 'alminium'"
+    mysql alminium -e "FLUSH PRIVILEGES"
+    mysql alminium -e "DROP DATABASE alminium"
     rm -fr /opt/alminium /var/opt/alminium
 fi
 


### PR DESCRIPTION
**【内容】**
再インストール時に以下のエラーが出るので、アンインストール時にalminiumユーザを削除するようにした。

```
ERROR 1396 (HY000) at line 2: Operation CREATE USER failed for 'alminium'@'%'
```

`GRANT` と `CREATE USER` でそれぞれ別のユーザを作成している。
`alminium@localhost` しか使用しないので `CREATE USER` は削除した。

``` mysql
mysql> select User,Host from mysql.user;
+----------+-----------+
| User     | Host      |
+----------+-----------+
| alminium | %         |
| alminium | localhost |
| root     | 127.0.0.1 |
| root     | localhost |
+----------+-----------+
```

**【動作確認】**
- Ubuntu 12.04.5 LTS x86_64
- CentOS 6.5 x86_64
