### PR TITLE
Add 'yum update -y ca-certificates'

### DIFF
--- a/inst-script/rhel6/pre-install
+++ b/inst-script/rhel6/pre-install
@@ -11,6 +11,7 @@ echo
 echo -n "アプリケーションを動作させるためにセキュリティの設定を行いますか?[Y/n]"
 read USE_DISABLE_SECURITY
 fi
+yum update -y ca-certificates
 if [ -f /etc/yum.repos.d/epel.repo ]
 then
   CHK=`grep "enabled=1" /etc/yum.repos.d/epel.repo`


### PR DESCRIPTION
GMO CLOUD VPS上の、まっさらな CentOS 6.2 x64 にインストールを行ったところ、以下のエラーが表示されインストールが完了しませんでした。

Error: Cannot retrieve metalink for repository: epel.

[こちら](http://qiita.com/a_yasui/items/d714eb9310f1d3b7ec1f)のページの情報を参考に、

yum update -y ca-certificates

を追加したところ、無事インストールが完了しました。
