### PR TITLE
imagemagick が rmagick のビルド時に必要なのでパッケージリストに追加

### DIFF
--- a/inst-script/debian/packages.lst
+++ b/inst-script/debian/packages.lst
@@ -7,6 +7,7 @@ mercurial
 mysql-client
 mysql-server
 ruby1.9.3
+imagemagick
 libmagickcore-dev
 libmagickwand-dev
 #rubygems


### PR DESCRIPTION
以下の環境で `# bash ./smelt` を実行したところ、gem の rmagick をインストールするときにコケてしまうので、packages.lst に imagemagick を追加しました。
- Ubuntu 12.04 LTS および 14.04 LTS
- 64bit
- サーバ版
