### PR TITLE
(fixes #167) redmine_code_reviewプラグインのインストールが失敗する件の対処

### DIFF
--- a/redmine/setup/redmine-plugins.lst
+++ b/redmine/setup/redmine-plugins.lst
@@ -10,7 +10,7 @@
 redmine_xls_export,0.2.1.t4,https://github.com/two-pack/redmine_xls_export.git
 redmine_plugin_views_revisions,redmine_plugin_views_revisions,http://www.redmine.org/attachments/download/7705/redmine_plugin_views_revisions_v001.zip
 redmine_importer,master,https://github.com/zh/redmine_importer.git
-redmine_code_review,default,https://bitbucket.org/haru_iida/redmine_code_review
+redmine_code_review,0.6.4,https://bitbucket.org/haru_iida/redmine_code_review
 redmine_hudson,redmine2.x,https://bitbucket.org/okamototk/redmine_hudson
 ##redmine_ms_projects,master,https://github.com/suer/redmine_ms_projects.git
 redmine_backlogs,master,https://github.com/backlogs/redmine_backlogs.git


### PR DESCRIPTION
【原因】
プラグインの最新版がredmine3.0対応になり、redmine2.5にインストールできなくなった。

【処置】
インストール対象のプラグインのバージョンを指定するようにした。
