### PR TITLE
Ubuntu 14.04.2 LTS(x64)にてalminiumが正常にinstallできるようにする

### DIFF
--- a/redmine/Gemfile_backlogs
+++ b/redmine/Gemfile_backlogs
@@ -1,0 +1,85 @@
+source 'https://rubygems.org'
+
+redmine_version_file = File.expand_path("../../../lib/redmine/version.rb",__FILE__)
+if (!File.exists? redmine_version_file)
+  redmine_version_file = File.expand_path("lib/redmine/version.rb");
+end
+version_file = IO.read(redmine_version_file)
+redmine_version_minor = version_file.match(/MINOR =/).post_match.match(/\d/)[0].to_i
+redmine_version_major = version_file.match(/MAJOR =/).post_match.match(/\d/)[0].to_i
+
+chiliproject_file = File.dirname(__FILE__) + "/lib/chili_project.rb"
+chiliproject = File.file?(chiliproject_file)
+
+deps = Hash.new
+@dependencies.map{|dep| deps[dep.name] = dep }
+rails3 = Gem::Dependency.new('rails', '~>3.0')
+RAILS_VERSION_IS_3 = rails3 =~ deps['rails']
+
+gem "holidays", "~>1.0.3"
+gem "icalendar"
+# Choose nokogiri depending on RM version. This is done to avoid conflict with
+# RM 2.3 which pinned nokogiri at "<1.6.0" for group :test.
+if (redmine_version_major == 2 && redmine_version_minor == 3)
+gem "nokogiri", "< 1.6.0"
+else
+gem "nokogiri"
+end
+gem "open-uri-cached"
+#gem "prawn"
+gem 'json'
+gem "system_timer" if RUBY_VERSION =~ /^1\.8\./ && RUBY_PLATFORM =~ /darwin|linux/
+
+group :development do
+  gem "inifile"
+end
+
+group :test do
+  gem 'chronic'
+  gem 'ZenTest', "=4.5.0" # 4.6.0 has a nasty bug that breaks autotest
+  gem 'autotest-rails'
+  if RAILS_VERSION_IS_3
+    unless chiliproject
+      gem 'capybara', "~> 1.1" if ENV['IN_RBL_TESTENV'] == 'true' # redmine 2.3 conflicts
+      gem "faye-websocket", "~>0.4.7"
+      gem "poltergeist", "~>1.0"
+    end
+    gem 'cucumber-rails', :require => false
+    gem "culerity"
+  else
+    unless chiliproject
+      gem "capybara", "~>1.1.0"
+      gem "poltergeist", "~>0.6.0"
+    end
+    gem "cucumber", "=1.1.0"
+    gem 'cucumber-rails2', "~> 0.3.5"
+    gem "culerity", "=0.2.15"
+  end
+  gem "database_cleaner"
+  if RAILS_VERSION_IS_3
+    gem "gherkin", "~> 2.6"
+  else
+    gem "gherkin", "~> 2.5.0"
+  end
+  gem "redgreen" if RUBY_VERSION < "1.9"
+  if RAILS_VERSION_IS_3
+    gem "rspec", '~>2.11.0'
+    gem "rspec-rails", '~> 2.11.0'
+  else
+    gem "rspec", "=1.3.1"
+    gem "rspec-rails", "=1.3.3"
+  end
+  if RUBY_VERSION >= "1.9"
+    gem "simplecov", "~>0.6"
+  else
+    gem "rcov",  "=0.9.11"
+  end
+  gem "ruby-prof", :platforms => [:ruby]
+  gem "spork"
+  gem "test-unit", "=1.2.3" if RUBY_VERSION >= "1.9" and ENV['IN_RBL_TESTENV'] == 'true'
+  gem "timecop", '~> 0.3.5'
+end
+
+# moved out of the dev group so backlogs can be tested by the user after install. Too many issues of weird setups with apache, nginx, etc.
+# thin doesn't work for jruby
+gem "thin", :platforms => [:ruby]

--- a/redmine/Gemfile_redmine_v2.5.2
+++ b/redmine/Gemfile_redmine_v2.5.2
@@ -1,0 +1,111 @@
+source 'https://rubygems.org'
+
+gem "rails", "3.2.19"
+gem "rake", "~> 10.1.1"
+gem "jquery-rails", "~> 2.0.2"
+gem "coderay", "~> 1.1.0"
+gem "fastercsv", "~> 1.5.0", :platforms => [:mri_18, :mingw_18, :jruby]
+gem "builder", "3.0.0"
+gem "mime-types"
+gem "awesome_nested_set", "2.1.6"
+gem "prawn", "1.3.0"
+gem "open-uri-cached"
+gem "nokogiri"
+
+# Optional gem for LDAP authentication
+group :ldap do
+  gem "net-ldap", "~> 0.3.1"
+end
+
+# Optional gem for OpenID authentication
+group :openid do
+  gem "ruby-openid", "~> 2.3.0", :require => "openid"
+  gem "rack-openid"
+end
+
+platforms :mri, :mingw do
+  # Optional gem for exporting the gantt to a PNG file, not supported with jruby
+  group :rmagick do
+    # RMagick 2 supports ruby 1.9
+    # RMagick 1 would be fine for ruby 1.8 but Bundler does not support
+    # different requirements for the same gem on different platforms
+    gem "rmagick", ">= 2.0.0"
+  end
+
+  # Optional Markdown support, not for JRuby
+  group :markdown do
+    # TODO: upgrade to redcarpet 3.x when ruby1.8 support is dropped
+    gem "redcarpet", "~> 2.3.0"
+  end
+end
+
+platforms :jruby do
+  # jruby-openssl is bundled with JRuby 1.7.0
+  gem "jruby-openssl" if Object.const_defined?(:JRUBY_VERSION) && JRUBY_VERSION < '1.7.0'
+  gem "activerecord-jdbc-adapter", "~> 1.3.2"
+end
+
+# Include database gems for the adapters found in the database
+# configuration file
+require 'erb'
+require 'yaml'
+database_file = File.join(File.dirname(__FILE__), "config/database.yml")
+if File.exist?(database_file)
+  database_config = YAML::load(ERB.new(IO.read(database_file)).result)
+  adapters = database_config.values.map {|c| c['adapter']}.compact.uniq
+  if adapters.any?
+    adapters.each do |adapter|
+      case adapter
+      when 'mysql2'
+        gem "mysql2", "~> 0.3.11", :platforms => [:mri, :mingw]
+        gem "activerecord-jdbcmysql-adapter", :platforms => :jruby
+      when 'mysql'
+        gem "mysql", "~> 2.8.1", :platforms => [:mri, :mingw]
+        gem "activerecord-jdbcmysql-adapter", :platforms => :jruby
+      when /postgresql/
+        gem "pg", ">= 0.11.0", :platforms => [:mri, :mingw]
+        gem "activerecord-jdbcpostgresql-adapter", :platforms => :jruby
+      when /sqlite3/
+        gem "sqlite3", :platforms => [:mri, :mingw]
+        gem "activerecord-jdbcsqlite3-adapter", :platforms => :jruby
+      when /sqlserver/
+        gem "tiny_tds", "~> 0.5.1", :platforms => [:mri, :mingw]
+        gem "activerecord-sqlserver-adapter", :platforms => [:mri, :mingw]
+      else
+        warn("Unknown database adapter `#{adapter}` found in config/database.yml, use Gemfile.local to load your own database gems")
+      end
+    end
+  else
+    warn("No adapter found in config/database.yml, please configure it first")
+  end
+else
+  warn("Please configure your config/database.yml first")
+end
+
+group :development do
+  gem "rdoc", ">= 2.4.2"
+  gem "yard"
+end
+
+group :test do
+  gem "shoulda", "~> 3.3.2"
+  gem "shoulda-matchers", "1.4.1"
+  gem "mocha", "~> 1.0.0", :require => 'mocha/api'
+  if RUBY_VERSION >= '1.9.3'
+    gem "capybara", "~> 2.1.0"
+    gem "selenium-webdriver"
+  end
+end
+
+local_gemfile = File.join(File.dirname(__FILE__), "Gemfile.local")
+if File.exists?(local_gemfile)
+  puts "Loading Gemfile.local ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(local_gemfile)
+end
+
+# Load plugins' Gemfiles
+Dir.glob File.expand_path("../plugins/*/Gemfile", __FILE__) do |file|
+  puts "Loading #{file} ..." if $DEBUG # `ruby -d` or `bundle -v`
+  #TODO: switch to "eval_gemfile file" when bundler >= 1.2.0 will be required (rails 4)
+  instance_eval File.read(file), file
+end

--- a/redmine/setup/redmine-plugins.lst
+++ b/redmine/setup/redmine-plugins.lst
@@ -10,7 +10,7 @@
 redmine_xls_export,0.2.1.t4,https://github.com/two-pack/redmine_xls_export.git
 redmine_plugin_views_revisions,redmine_plugin_views_revisions,http://www.redmine.org/attachments/download/7705/redmine_plugin_views_revisions_v001.zip
 redmine_importer,master,https://github.com/zh/redmine_importer.git
-redmine_code_review,default,https://bitbucket.org/haru_iida/redmine_code_review
+redmine_code_review,redmine_code_review,https://bitbucket.org/haru_iida/redmine_code_review/downloads/redmine_code_review-0.6.5.zip
 redmine_hudson,redmine2.x,https://bitbucket.org/okamototk/redmine_hudson
 ##redmine_ms_projects,master,https://github.com/suer/redmine_ms_projects.git
 redmine_backlogs,master,https://github.com/backlogs/redmine_backlogs.git
@@ -26,7 +26,7 @@ clipboard_image_paste,master,https://github.com/peclik/clipboard_image_paste.git
 #redmine_lightbox,master,https://github.com/zipme/redmine_lightbox.git
 redmine_banner,master,https://github.com/akiko-pusu/redmine_banner.git
 open_flash_chart,master,https://github.com/pullmonkey/open_flash_chart.git
-redmine_charts,develop,https://github.com/drakontia/redmine_charts.git
+redmine_charts,c0070d2,https://github.com/drakontia/redmine_charts.git
 redmine_local_avatars,master,https://github.com/luckval/redmine_local_avatars.git
 redmine_git_branch_hook,master,https://github.com/mikoto20000/redmine_git_branch_hook.git
 # advanced_roadmapはbacklogsと競合するためどちらかを選択

--- a/smelt
+++ b/smelt
@@ -279,6 +279,8 @@ then
 fi
 
 cp     redmine/Gemfile.local   $INSTALL_DIR/
+mv     $INSTALL_DIR/Gemfile    $INSTALL_DIR/Gemfile.org
+cp     redmine/Gemfile_redmine_v2.5.2 $INSTALL_DIR/Gemfile
 $CPCMD redmine/config/*        $INSTALL_DIR/config/
 $CPCMD redmine/public/themes/* $INSTALL_DIR/public/themes/
 


### PR DESCRIPTION
  現状、defaultのリポジトリをcheckoutするとRedmine v2.5.2に対応しておらず
  redmine_code_review plugin requires Redmine 3.0.0 or higher
  となりbundle install時にエラーとなってしまう為。

redmine_chartsをdevelopの最新を取得せず、c0070d2のcommitまでの取得に変更する。
  Bundlerにて、rspec-mocksの依存関係が満たせないため。

> Bundler could not find compatible versions for gem "rspec-mocks":
>         In Gemfile:
>           rspec-rails (~> 2.11.0) ruby depends on
>             rspec (~> 2.11.0) ruby depends on
>               rspec-mocks (~> 2.11.0) ruby
> 
> ```
>       rspec-activemodel-mocks (>= 0) ruby depends on
>         rspec-mocks (~> 3.0.0) ruby
> ```
